### PR TITLE
chore: remove docker ignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,0 @@
-# Assets
-assets/
-
-# Build
-build/


### PR DESCRIPTION
### Changes

- Removed `.dockerignore`, no longer necessary