### PR TITLE
fix(#9): generate new uuid on create endpoints

### DIFF
--- a/internal/app/helper/uuid.go
+++ b/internal/app/helper/uuid.go
@@ -5,6 +5,13 @@ import (
 	"github.com/ikti-its/khanza-api/internal/app/exception"
 )
 
+func MustNew() uuid.UUID {
+	id, err := uuid.NewRandom()
+	exception.PanicIfError(err, "Failed to generate UUID")
+
+	return id
+}
+
 func MustParse(s string) uuid.UUID {
 	id, err := uuid.Parse(s)
 	exception.PanicIfError(err, "Failed to parse UUID")

--- a/internal/modules/akun/internal/usecase/akun_usecase.go
+++ b/internal/modules/akun/internal/usecase/akun_usecase.go
@@ -37,6 +37,7 @@ func (u *AkunUseCase) Create(request *model.CreateAkunRequest, updater string) m
 	}
 
 	akun := entity.Akun{
+		Id:       helper.MustNew(),
 		Email:    request.Email,
 		Password: string(encrypted),
 		Foto:     request.Foto,

--- a/internal/modules/kehadiran/internal/usecase/cuti_usecase.go
+++ b/internal/modules/kehadiran/internal/usecase/cuti_usecase.go
@@ -20,6 +20,7 @@ func NewCutiUseCase(repository *repository.CutiRepository) *CutiUseCase {
 
 func (u *CutiUseCase) Create(request *model.CutiRequest, updater string) model.CutiResponse {
 	cuti := entity.Cuti{
+		Id:             helper.MustNew(),
 		IdPegawai:      helper.MustParse(request.IdPegawai),
 		TanggalMulai:   helper.ParseTime(request.TanggalMulai, "2006-01-02"),
 		TanggalSelesai: helper.ParseTime(request.TanggalSelesai, "2006-01-02"),

--- a/internal/modules/kehadiran/internal/usecase/kehadiran_usecase.go
+++ b/internal/modules/kehadiran/internal/usecase/kehadiran_usecase.go
@@ -20,6 +20,7 @@ func NewKehadiranUseCase(repository *repository.KehadiranRepository) *KehadiranU
 
 func (u *KehadiranUseCase) Attend(request *model.AttendKehadiranRequest) model.KehadiranResponse {
 	kehadiran := entity.Kehadiran{
+		Id:              helper.MustNew(),
 		IdPegawai:       helper.MustParse(request.IdPegawai),
 		IdJadwalPegawai: helper.MustParse(request.IdJadwalPegawai),
 		Tanggal:         helper.ParseTime(request.Tanggal, "2006-01-02"),

--- a/internal/modules/pegawai/internal/usecase/pegawai_usecase.go
+++ b/internal/modules/pegawai/internal/usecase/pegawai_usecase.go
@@ -29,6 +29,7 @@ func (u *PegawaiUseCase) Create(request *model.PegawaiRequest, user string) mode
 
 	updater := helper.MustParse(user)
 	pegawai := entity.Pegawai{
+		Id:           helper.MustNew(),
 		IdAkun:       helper.MustParse(request.IdAkun),
 		NIP:          request.NIP,
 		Nama:         request.Nama,


### PR DESCRIPTION
### Fix

Resolve #9 

### Reason

Currently implemented logic is not generating new UUID on create endpoints, therefore a null UUID (`00000000-0000-0000-0000-000000000000`) is set automatically